### PR TITLE
feat: add supabase schema and server client

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,20 +1,22 @@
 import { createClient } from '@supabase/supabase-js'
 
-type SupabaseClientOptions = {
-  persistSession?: boolean
-}
-
-export const createSupabaseAdminClient = () => {
+// Create a server-side Supabase client with service role
+export const createServerSupabaseClient = () => {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !serviceRoleKey) {
-    throw new Error('Brak konfiguracji Supabase. Ustaw NEXT_PUBLIC_SUPABASE_URL i SUPABASE_SERVICE_ROLE_KEY w środowisku.')
+    throw new Error('Missing Supabase environment variables')
   }
 
-  const options: SupabaseClientOptions = { persistSession: false }
-
-  return createClient(supabaseUrl, serviceRoleKey, { auth: options })
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+    },
+  })
 }
+
+// Backwards compatibility for existing imports
+export const createSupabaseAdminClient = createServerSupabaseClient
 
 


### PR DESCRIPTION
## Summary
- add full SQL schema and RLS policies for Supabase
- expose server-side Supabase client and keep admin alias
- validate reservations API requests with Zod

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any types)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689662fa5be08326a1265a06f274f020