### PR TITLE
Show current bookings on dashboard and wire campsite reservations tab

### DIFF
--- a/src/app/campsites/page.tsx
+++ b/src/app/campsites/page.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Plus, Edit, Trash2, Search, Eye, Calendar, Users, MapPin, Star, Zap, Droplet, Wifi } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { CampsiteBookings } from '@/components/campsite-bookings'
 
 interface Spot {
   id: string
@@ -260,7 +261,13 @@ export default function CampsitesPage() {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="flex justify-between items-center mb-6">
+      <Tabs defaultValue="spots">
+        <TabsList className="mb-6">
+          <TabsTrigger value="spots">Pola</TabsTrigger>
+          <TabsTrigger value="bookings">Rezerwacje</TabsTrigger>
+        </TabsList>
+        <TabsContent value="spots">
+          <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">Pola namiotowe</h1>
         <Button onClick={() => setIsCreateDialogOpen(true)}>
           <Plus className="w-4 h-4 mr-2" />
@@ -616,7 +623,7 @@ export default function CampsitesPage() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold mb-4 text-red-600">Potwierdź usunięcie</h3>
-            
+
             <div className="space-y-4">
               <p className="text-gray-700">
                 Czy na pewno chcesz usunąć pole <strong>{deletingSpot?.name}</strong>?
@@ -647,6 +654,14 @@ export default function CampsitesPage() {
           </div>
         </div>
       )}
+        </TabsContent>
+        <TabsContent value="bookings">
+          <div className="flex justify-between items-center mb-6">
+            <h1 className="text-3xl font-bold">Rezerwacje</h1>
+          </div>
+          <CampsiteBookings bookings={bookings} spots={spots} onUpdate={loadData} />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,27 @@ export default async function Page() {
     bookingsData = []
   }
 
+  // Helpers to get today's local date boundaries
+  const startOfLocalDay = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)
+  const endOfLocalDay = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)
+  const parseLocalDateString = (dateStr: string) => {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+      const [y, m, d] = dateStr.split('-').map(Number)
+      return new Date(y, (m as number) - 1, d as number)
+    }
+    return new Date(dateStr)
+  }
+
+  const now = new Date()
+  const todayStart = startOfLocalDay(now)
+  const todayEnd = endOfLocalDay(now)
+  const activeBookings = bookingsData.filter(b => {
+    const bookingDate = parseLocalDateString(b.Data)
+    return bookingDate >= todayStart && bookingDate <= todayEnd
+  })
+
   return (
     <div className="flex flex-1 flex-col">
       <div className="@container/main flex flex-1 flex-col gap-2">
@@ -22,7 +43,7 @@ export default async function Page() {
           <div className="px-4 lg:px-6">
             <ChartAreaInteractive />
           </div>
-          <DataTable data={bookingsData} />
+          <DataTable data={activeBookings} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Filter dashboard reservations to only show today's bookings
- Add a reservations tab to the campsites page using `CampsiteBookings`

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6896f77c0c288326a4c137504cfff81f