### PR TITLE
Show only existing add-ons and rename electricity to bonfire

### DIFF
--- a/src/components/booking-form.tsx
+++ b/src/components/booking-form.tsx
@@ -414,9 +414,9 @@ export function BookingForm({ booking, onSave, onCancel }: BookingFormProps) {
                 id="electricity"
                 checked={watch("electricity")}
                 onCheckedChange={(checked) => setValue("electricity", Boolean(checked))}
-                aria-label="Prąd"
+                aria-label="Ognisko"
               />
-              <Label htmlFor="electricity" className="mb-0">Prąd</Label>
+              <Label htmlFor="electricity" className="mb-0">Ognisko</Label>
             </div>
           </div>
           <div className="flex items-center justify-between rounded-md border p-3">

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -302,7 +302,7 @@ function TableCellViewer({ item, onUpdate }: {
                   checked={editedData.electricity || false}
                   onCheckedChange={(checked) => setEditedData(prev => ({ ...prev, electricity: checked as boolean }))}
                 />
-                <Label htmlFor="electricity">Prąd</Label>
+                <Label htmlFor="electricity">Ognisko</Label>
               </div>
               <div className="flex items-center gap-2">
                 <Checkbox
@@ -644,7 +644,7 @@ export function DataTable({
     },
     {
       accessorKey: "electricity",
-      header: "Prąd",
+      header: "Ognisko",
       cell: ({ row }) => (
         <div className="flex justify-center">
           {row.original.electricity ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}
@@ -888,7 +888,7 @@ export function DataTable({
                             <div><span className="font-medium">Godzina:</span> {row.original.godzinaSplywu || '-'}</div>
                             <div className="flex items-center gap-2"><span className="font-medium">Wyżywienie:</span> {row.original.meals ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}</div>
                             <div className="flex items-center gap-2"><span className="font-medium">Transport:</span> {row.original.groupTransport ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}</div>
-                            <div className="flex items-center gap-2"><span className="font-medium">Prąd:</span> {row.original.electricity ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}</div>
+                            <div className="flex items-center gap-2"><span className="font-medium">Ognisko:</span> {row.original.electricity ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}</div>
                             <div className="flex items-center gap-2"><span className="font-medium">Altana:</span> {row.original.gazebo ? <IconCheck className="text-green-500" /> : <IconX className="text-red-500" />}</div>
                             <div><span className="font-medium">Kierowcy:</span> {row.original.driversCount || 0}</div>
                             <div><span className="font-medium">Kapoki dziecięce:</span> {row.original.childKayaks || 0}</div>

--- a/src/components/important-bookings-card.tsx
+++ b/src/components/important-bookings-card.tsx
@@ -7,7 +7,7 @@ import { Booking } from "@/types/booking"
 import { format } from "date-fns"
 import { pl } from "date-fns/locale"
 import { isAfter, isSameDay } from "date-fns"
-import { IconCheck, IconX } from "@tabler/icons-react"
+import { IconCheck } from "@tabler/icons-react"
 
 interface ImportantBookingsCardProps {
   bookings: Booking[]
@@ -16,7 +16,7 @@ interface ImportantBookingsCardProps {
 
 export function ImportantBookingsCard({ bookings }: ImportantBookingsCardProps) {
   // Tylko rezerwacje: Aktualne (dziś) lub Nadchodzące (po dziś)
-  // ORAZ mają przynajmniej jeden z dodatków: Wyżywienie, Transport, Prąd, Altana,
+  // ORAZ mają przynajmniej jeden z dodatków: Wyżywienie, Transport, Ognisko, Altana,
   // dostawki (>0) lub kapoki dziecięce (>0)
   const today = new Date();
 
@@ -44,7 +44,7 @@ export function ImportantBookingsCard({ bookings }: ImportantBookingsCardProps) 
         </CardHeader>
         <CardContent>
           <div className="text-muted-foreground py-2">
-            Brak rezerwacji spełniających kryteria (Aktualne/Nadchodzące z: Wyżywienie, Transport, Prąd, Altana, Dostawki lub Kapoki dziecięce)
+            Brak rezerwacji spełniających kryteria (Aktualne/Nadchodzące z: Wyżywienie, Transport, Ognisko, Altana, Dostawki lub Kapoki dziecięce)
           </div>
         </CardContent>
       </Card>
@@ -63,12 +63,12 @@ export function ImportantBookingsCard({ bookings }: ImportantBookingsCardProps) 
             const addonsToShow = [
               { label: "Wyżywienie", value: booking.meals, type: "boolean" as const },
               { label: "Transport", value: booking.groupTransport, type: "boolean" as const },
-              { label: "Prąd", value: booking.electricity, type: "boolean" as const },
+              { label: "Ognisko", value: booking.electricity, type: "boolean" as const },
               { label: "Altana", value: booking.gazebo, type: "boolean" as const },
               { label: "Dostawki", value: booking.deliveries, type: "number" as const },
               { label: "Kapoki dziecięce", value: booking.childKayaks, type: "number" as const },
             ].filter((a) => {
-              if (a.type === "boolean") return typeof a.value !== "undefined";
+              if (a.type === "boolean") return a.value === true;
               if (a.type === "number") return typeof a.value === "number" && a.value > 0;
               return false;
             });
@@ -90,11 +90,7 @@ export function ImportantBookingsCard({ bookings }: ImportantBookingsCardProps) 
                         <div key={idx} className="flex items-center gap-2">
                           <span className="text-sm text-muted-foreground">{a.label}:</span>
                           {a.type === "boolean" ? (
-                            a.value ? (
-                              <IconCheck className="text-green-500" />
-                            ) : (
-                              <IconX className="text-red-500" />
-                            )
+                            <IconCheck className="text-green-500" />
                           ) : (
                             <span className="text-sm font-medium">{String(a.value)}</span>
                           )}


### PR DESCRIPTION
## Summary
- show only true or positive add-ons in Important bookings
- rename Prąd add-on to Ognisko in reservations components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898de33d56083268add8ba73d4ecb1d