### PR TITLE
Validate kayak availability before saving reservations

### DIFF
--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import type { Booking } from '@/types/booking'
 import { bookingSchema } from '@/types/booking'
+import type { Equipment } from '@/types/inventory'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 
 export const dynamic = 'force-dynamic'
@@ -16,6 +17,66 @@ export const revalidate = 0
  *  - PUT  /api/data              -> częściowa aktualizacja jednego rekordu po id
  *  - DELETE /api/data?id={id}    -> usunięcie jednego rekordu po id
  */
+
+async function checkKayakAvailability(
+  supabase: ReturnType<typeof createServerSupabaseClient>,
+  booking: Booking
+) {
+  try {
+    const { data: equipmentRows } = await supabase
+      .from('equipment')
+      .select('payload')
+    const equipment = (equipmentRows ?? []).map(
+      (r: { payload: Equipment }) => r.payload
+    )
+    const totalTwo = equipment
+      .filter(
+        (e) => e.name.toLowerCase().includes('dwu') || e.name.includes('2')
+      )
+      .reduce((sum, e) => sum + (e.quantity || 0), 0)
+    const totalOne = equipment
+      .filter(
+        (e) => e.name.toLowerCase().includes('jedn') || e.name.includes('1')
+      )
+      .reduce((sum, e) => sum + (e.quantity || 0), 0)
+
+    const { data: existingRows } = await supabase
+      .from('reservations')
+      .select('payload')
+    const sameDay = (existingRows ?? [])
+      .map((r: { payload: Booking }) => r.payload)
+      .filter((b) => b.Data === booking.Data && b.id !== booking.id)
+
+    const reservedTwo = sameDay.reduce(
+      (sum, b) => sum + (Number(b.dwuosobowe) || 0),
+      0
+    )
+    const reservedOne = sameDay.reduce(
+      (sum, b) => sum + (Number(b.jednoosobowe) || 0),
+      0
+    )
+
+    const availableTwo = totalTwo - reservedTwo
+    const availableOne = totalOne - reservedOne
+
+    if ((booking.dwuosobowe || 0) > availableTwo) {
+      return {
+        ok: false,
+        message: `Brak dostępnych kajaków dwuosobowych na ten dzień. Pozostało ${availableTwo}`,
+      }
+    }
+    if ((booking.jednoosobowe || 0) > availableOne) {
+      return {
+        ok: false,
+        message: `Brak dostępnych kajaków jednoosobowych na ten dzień. Pozostało ${availableOne}`,
+      }
+    }
+    return { ok: true }
+  } catch {
+    // W razie problemów z odczytem danych nie blokuj zapisu
+    return { ok: true }
+  }
+}
 
 export async function GET() {
   try {
@@ -68,12 +129,21 @@ export async function POST(request: NextRequest) {
     const incoming = body as Partial<Booking>
     const id = typeof incoming.id === 'number' ? incoming.id : Date.now()
     const nowIso = new Date().toISOString()
-      const payload: Booking = {
-        ...(incoming as Booking),
-        id,
-        createdAt: incoming.createdAt ?? nowIso,
-        updatedAt: nowIso,
-      }
+    const payload: Booking = {
+      ...(incoming as Booking),
+      id,
+      createdAt: incoming.createdAt ?? nowIso,
+      updatedAt: nowIso,
+    }
+
+    const availability = await checkKayakAvailability(supabase, payload)
+    if (!availability.ok) {
+      return NextResponse.json(
+        { success: false, message: availability.message },
+        { status: 400 }
+      )
+    }
+
     const { error } = await supabase.from('reservations').upsert({ id, payload })
     if (error) throw error
     return NextResponse.json({ success: true, message: 'Rezerwacja zapisana pomyślnie', booking: payload })
@@ -114,6 +184,15 @@ export async function PUT(request: NextRequest) {
         ...partial,
         updatedAt: new Date().toISOString(),
       }
+
+    const availability = await checkKayakAvailability(supabase, merged)
+    if (!availability.ok) {
+      return NextResponse.json(
+        { success: false, message: availability.message },
+        { status: 400 }
+      )
+    }
+
     const { error } = await supabase
       .from('reservations')
       .update({ payload: merged })

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -371,6 +371,10 @@ export function DataTable({
 }) {
   const [data, setData] = React.useState(() => initialData)
 
+  React.useEffect(() => {
+    setData(initialData)
+  }, [initialData])
+
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({
       Email: false,


### PR DESCRIPTION
## Summary
- Sync DataTable with incoming data so filters reflect latest rows
- Prevent overbooking by checking kayak inventory on the server when creating or updating reservations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0d449f4883268d6e3d215ac396eb