### PR TITLE
fix: enable reservation row actions

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -705,16 +705,24 @@ export function DataTable({
               variant="ghost"
               className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
               size="icon"
+              onClick={(e) => e.stopPropagation()}
             >
               <IconDotsVertical />
               <span className="sr-only">Open menu</span>
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-32">
-            <DropdownMenuItem onClick={() => {
-              setEditingBooking(row.original)
-              setIsDrawerOpen(true)
-            }}>
+          <DropdownMenuContent
+            align="end"
+            className="w-32"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                setEditingBooking(row.original)
+                setIsDrawerOpen(true)
+              }}
+            >
               Edytuj
             </DropdownMenuItem>
             <DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- ensure reservation action menu does not toggle row expansion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4c9b3db48326add6f59ac49322eb