### PR TITLE
fix: ensure campsite spot route loads

### DIFF
--- a/src/app/api/campsites/spots/[id]/route.ts
+++ b/src/app/api/campsites/spots/[id]/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { createSupabaseAdminClient } from '@/lib/supabase/server'
 
 export const dynamic = 'force-dynamic'


### PR DESCRIPTION
## Summary
- refactor campsite spot API to use type-only NextRequest import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba154cef4832692310eb109a94c57